### PR TITLE
Fix ESM build naming to mjs and importing from other applications using ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "main": "./lib/index.cjs.js",
   "module": "./lib/index.esm.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/index.esm.mjs",
+      "require": "./lib/index.cjs.js"
+    }
+  },
   "scripts": {
     "build": "rm -rf lib; rollup -c ./rollup.config.mjs",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Declarative table generator for for the @react-pdf/renderer.",
   "main": "./lib/index.cjs.js",
-  "module": "./lib/index.esm.js",
+  "module": "./lib/index.esm.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,6 +10,7 @@ export default [
             dir: 'lib',
             format: 'cjs',
             sourcemap: true,
+            entryFileNames: '[name].js',
         },
         external: ['@react-pdf/renderer', '@react-pdf/stylesheet', 'react'],
         plugins: [
@@ -27,6 +28,7 @@ export default [
             dir: 'lib',
             format: 'es',
             sourcemap: true,
+            entryFileNames: '[name].mjs',
         },
         external: ['@react-pdf/renderer', '@react-pdf/stylesheet', 'react'],
         plugins: [


### PR DESCRIPTION
Hello!

I was converting my team's backend application to use esm. It compiled fine using rollup but crashed in runtime due to node attempting load the cjs build of react-pdf-table. 

This PR fixes this with two steps:

1. Ensuring that rollup gives the `mjs` file extension to the esm file, that it is, it is now named `index.esm.mjs`. Otherwise node will treat at commonjs (at least for me, using node v20)
2. Specifying the `exports` field in `package.json` such that imports from other applications gets directed properly to the esm build, or else it will use the cjs build based on the `main` field in package.json